### PR TITLE
fixed markdown link resolution if no asset

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -92,6 +92,8 @@ const updateImagePathsWithLocalPaths = (markdown, images) => {
 
 const updateAssetPathsWithLocalPaths = (markdown, assets) => {
   return markdown.replace(MARKDOWN_ASSET_REGEXP_GLOBAL, (...match) =>
-    match[0].replace(match[1], assets[match[1]].localPath)
+    assets[match[1]]
+      ? match[0].replace(match[1], assets[match[1]].localPath)
+      : match[0]
   );
 };


### PR DESCRIPTION
Hi, i tryed your source plugin and encountered an unexpected behaviour. 

If a markdown field contains links, there's some logic to resolve those to other assets managed by cockpit. In my case the links where pointing to an external website, which resulted in an error during the build.

This is a quick fix, which will only replace links that point to actual assets, otherwise just return the links.