### PR TITLE
Fixed errors thrown from an empty gallery

### DIFF
--- a/src/CockpitService.js
+++ b/src/CockpitService.js
@@ -95,6 +95,10 @@ module.exports = class CockpitService {
               const imageField = item[fieldName];
               let path = imageField.value.path;
 
+              if (path == null) {
+                return;
+              }
+
               trimAssetField(imageField);
 
               if (path.startsWith("/")) {
@@ -111,6 +115,10 @@ module.exports = class CockpitService {
               galleryField.value.forEach(galleryImageField => {
                 let path = galleryImageField.path;
 
+                if (path == null) {
+                  return;
+                }
+  
                 trimGalleryImageField(galleryImageField);
 
                 if (path.startsWith("/")) {

--- a/src/CollectionItemNodeFactory.js
+++ b/src/CollectionItemNodeFactory.js
@@ -42,9 +42,11 @@ const linkImageFieldsToImageNodes = (node, images) => {
       field.value___NODE = images[field.value].id;
       delete field.value;
     } else if (field.type === "gallery") {
-      field.value___NODE = field.value.map(
-        imageField => images[imageField.value].id
-      );
+      if (Array.isArray(field.value)) {
+        field.value___NODE = field.value.map(
+          imageField => images[imageField.value].id
+        );
+      }
       delete field.value;
     }
   });


### PR DESCRIPTION
As mentioned in this pull request https://github.com/fikaproductions/fika-gatsby-source-cockpit/pull/7, since the bug is already fixed in the previous commit.
So only the extra check on empty path is merged