### PR TITLE
Support for hierarchical collections

### DIFF
--- a/src/CockpitService.js
+++ b/src/CockpitService.js
@@ -135,7 +135,7 @@ module.exports = class CockpitService {
                 }
 
                 galleryImageField.value = path;
-       		    existingImages[path] = null;
+                existingImages[path] = null;
               });
             }
           });

--- a/src/CollectionItemNodeFactory.js
+++ b/src/CollectionItemNodeFactory.js
@@ -15,8 +15,13 @@ module.exports = class CollectionItemNodeFactory {
   }
 
   create(collectionItem) {
-    this.createNode(
-      createNodeFactory(this.collectionName, node => {
+    const children = collectionItem.hasOwnProperty('children')
+      ? collectionItem.children.map(childItem => {
+        return this.create(childItem);
+      })
+      : [];
+
+    const nodeFactory = createNodeFactory(this.collectionName, node => {
         node.id = generateNodeId(
           this.collectionName,
           node.lang === "any"
@@ -27,10 +32,14 @@ module.exports = class CollectionItemNodeFactory {
         linkAssetFieldsToAssetNodes(node, this.assets);
         linkMarkdownFieldsToMarkdownNodes(node, this.markdowns);
         linkCollectionLinkFieldsToCollectionItemNodes(node);
+      linkChildrenToParent(node, children);
 
         return node;
-      })(collectionItem)
-    );
+    });
+
+    const node = nodeFactory(collectionItem);
+    this.createNode(node);
+    return node;
   }
 };
 
@@ -110,4 +119,11 @@ const linkCollectionLinkFieldsToCollectionItemNodes = node => {
       delete field.value;
     }
   });
+};
+
+const linkChildrenToParent = (node, children) => {
+  if (Array.isArray(children) && children.length > 0) {
+    node.children___NODE = children.map(child => child.id);
+    delete node.children;
+  }
 };


### PR DESCRIPTION
As discussed in https://github.com/fikaproductions/fika-gatsby-source-cockpit/issues/11 I added support for hierarchical organized collections.

It works as far as I can tell but I am not totally sure if I use the best way to add the child nodes to the GraphQL tree. Looking at the [Gatsby Node APIs](https://www.gatsbyjs.org/docs/node-creation/) documentation I can see that there are methods to link nodes in a parent/child relationship however when I tried to implement this all i got in the Query result in the "children" field was an array of string ids, not the object. 

