### PR TITLE
Added cockpit entry data

### DIFF
--- a/src/CockpitService.js
+++ b/src/CockpitService.js
@@ -294,6 +294,13 @@ const createCollectionItem = (
 ) => {
   const item = {
     cockpitId: collectionEntry._id,
+    cockpitData:{
+      createdBy: collectionEntry._by,
+      modifiedBy: collectionEntry._mby,
+      created: new Date(collectionEntry._created*1000),
+      modified: new Date(collectionEntry._modified*1000),
+      id: collectionEntry._id
+    },
     lang: locale == null ? 'any' : locale,
     level: level,
   }

--- a/src/CockpitService.js
+++ b/src/CockpitService.js
@@ -294,13 +294,11 @@ const createCollectionItem = (
 ) => {
   const item = {
     cockpitId: collectionEntry._id,
-    cockpitData:{
-      createdBy: collectionEntry._by,
-      modifiedBy: collectionEntry._mby,
-      created: new Date(collectionEntry._created*1000),
-      modified: new Date(collectionEntry._modified*1000),
-      id: collectionEntry._id
-    },
+    cockpitCreated: new Date(collectionEntry._created*1000),
+    cockpitModified: new Date(collectionEntry._modified*1000),
+    //TODO: Replace with Users... once implemented (GitHub Issue #15)
+    cockpitBy: collectionEntry._by,
+    cockpitModifiedBy: collectionEntry._mby,
     lang: locale == null ? 'any' : locale,
     level: level,
   }


### PR DESCRIPTION
Hi,

I need information on my page about the entry in the cockpit itself. For example, the creation date of an entry and the modification date are relevant for me.

They're contained in the response as follows:
```json
{
    "fields": {
       ...
    },
    "entries": [
        {
            ...
            "_mby": "5c1fa17d6466377043000010",
            "_by": "5c1fa17d6466377043000010",
            "_modified": 1549904496,
            "_created": 1546113589,
            "_id": "5c27d23564663751760002c4"
        }
    ],
    "total": 1
}
```

Since the data itself is not really part of the element, I thought I'd do it similar to the cockpit ID and just insert a node containing the information, but keep it contained in an object.

Since I was going with the dates, I thought I'd just put all the available data into this object.

If you think this change makes sense, I would be happy if you could include it. I can also make adjustments to it.