### PR TITLE
fix(Gallery): Remote images include baseUrl

### DIFF
--- a/src/CockpitService.js
+++ b/src/CockpitService.js
@@ -165,7 +165,7 @@ module.exports = class CockpitService {
 
           if (path.startsWith('/')) {
             path = `${this.baseUrl}${path}`
-          } else {
+          } else if (!path.startsWith('http')) {
             path = `${this.baseUrl}/${path}`
           }
 


### PR DESCRIPTION
When using remote images in cockpit (e.g. S3), the baseUrl would be prepended in case of a gallery.
I reused your condition in the gallery part.

Maybe it makes sense to extract the path normalization into its own function and use that one in both places.