### PR TITLE
Set broken images either to "null" or replace them with a default image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+
+.idea

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,8 @@ plugins: [
       baseUrl:
         'YOUR_COCKPIT_API_BASE_URL', // (1)
       locales: ['EVERY_LANGUAGE_KEYS_DEFINED_IN_YOUR_COCKPIT_CONFIGURATION'], // (2)
-      collections: [] // (3)
+      collections: [], // (3)
+      brokenImageReplacement: null (4)
     },
   },
 ]
@@ -56,6 +57,7 @@ Notes:
 1. E.g. `'http://localhost:8080'`.
 2. E.g. `['en', 'fr']`.
 3. The specific Cockpit collections you want to fetch. If empty or null all collections will be fetched. E.g. `['Products', 'Menu']`
+4. Replacement for broken image links. If null the detected broken images will be removed. If an URL to an image the broken image will be replaced with this image.
 
 Adding the `gatsby-source-filesystem` dependency to your project grants access to the `publicURL` field resolver attribute on the file nodes that this plugin generates by extending the GraphQL type of the file nodes. So, as you can guess, the path specified in the plugin options could be anything, we do not need it to load any local files, we are just taking advantage of its extension of the file node type.
 

--- a/src/CollectionItemNodeFactory.js
+++ b/src/CollectionItemNodeFactory.js
@@ -55,15 +55,21 @@ module.exports = class CollectionItemNodeFactory {
 
 const linkImageFieldsToImageNodes = (node, images) => {
   getFieldsOfTypes(node, ['image']).forEach(field => {
-    field.value___NODE = images[field.value].id
-    delete field.value
+    if (images[field.value] !== null) {
+      field.value___NODE = images[field.value].id
+      delete field.value
+    } else {
+      field.value = null
+    }
   })
 
   getFieldsOfTypes(node, ['gallery']).forEach(field => {
     if (Array.isArray(field.value)) {
-      field.value___NODE = field.value.map(
-        imageField => images[imageField.value].id
-      )
+      field.value___NODE = field.value
+        .map(imageField =>
+          images[imageField.value] !== null ? images[imageField.value].id : null
+        )
+        .filter(imageId => imageId != null)
     }
     delete field.value
   })
@@ -71,8 +77,12 @@ const linkImageFieldsToImageNodes = (node, images) => {
 
 const linkAssetFieldsToAssetNodes = (node, assets) => {
   getFieldsOfTypes(node, ['asset']).forEach(field => {
-    field.value___NODE = assets[field.value].id
-    delete field.value
+    if (assets[field.value]) {
+      field.value___NODE = assets[field.value].id
+      delete field.value
+    } else {
+      field.value = null
+    }
   })
 }
 

--- a/src/FileNodeFactory.js
+++ b/src/FileNodeFactory.js
@@ -5,31 +5,48 @@ const { generateNodeId } = require('gatsby-node-helpers').default({
 })
 const { createRemoteFileNode } = require('gatsby-source-filesystem')
 const hash = require('string-hash')
+const fs = require('fs')
 
 module.exports = class FileNodeFactory {
-  constructor(createNode, store, cache) {
+  constructor(createNode, store, cache, reporter) {
     this.createNode = createNode
     this.store = store
     this.cache = cache
+    this.reporter = reporter
   }
 
   async createImageNode(path) {
-    return createRemoteFileNode({
+    const imageNode = await createRemoteFileNode({
       url: path,
       store: this.store,
       cache: this.cache,
       createNode: this.createNode,
       createNodeId: () => generateNodeId('Image', `${hash(path)}`),
     })
+
+    return this.checkIfDownloadIsSuccessful(path, imageNode)
   }
 
   async createAssetNode(path) {
-    return createRemoteFileNode({
+    const assetNode = await createRemoteFileNode({
       url: path,
       store: this.store,
       cache: this.cache,
       createNode: this.createNode,
       createNodeId: () => generateNodeId('Asset', `${hash(path)}`),
     })
+
+    return this.checkIfDownloadIsSuccessful(path, assetNode)
+  }
+
+  checkIfDownloadIsSuccessful(path, fileNode) {
+    const filePath = fileNode.absolutePath
+    const content = fs.readFileSync(filePath)
+    // TODO: evaluate if we should check for something else if Cockpit instance is localized
+    if (content.indexOf('<title>Authenticate Please!</title>') > 0) {
+      this.reporter.warn('Invalid asset url: ' + path)
+      return null
+    }
+    return fileNode
   }
 }


### PR DESCRIPTION
When a file that doesn't exist in /storage/uploads is requested Cockpit will not return a 404 error but instead it will return a HTML page with the login form. This leads to problems in Gatsby when this html page is downloaded and stored as the image. 
Later processing steps (e.g. resizing with`gatsby-plugin-sharp`) will assume that the file is an image and break the build when this is not the case. 

In order to avoid breaking the build I extended the gatsby-source-cockpit with the other to either remove the missing image or replace it with a default image. I also added a warning message that gives the URL of the missing image ... 

See readme.md on how to configure this.

The reason we need this is that clients frequently removed images in the finder and put the system in a non-building state and it was pretty time and work intensive to find and fix the problems everytime.