### PR TITLE
feat(Images): Add asset image support for wysiwyg node type

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -97,7 +97,8 @@ exports.sourceNodes = async (
       images,
       assets,
       markdowns,
-      layouts
+      layouts,
+      configOptions.baseUrl
     )
 
     collection.items.forEach(item => {
@@ -112,7 +113,8 @@ exports.sourceNodes = async (
       images,
       assets,
       markdowns,
-      layouts
+      layouts,
+      configOptions.baseUrl
     )
 
     singleton.items.forEach(item => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fika/gatsby-source-cockpit",
-  "version": "1.1.0",
-  "description": "This is a Gatsby version 2.x.x source plugin that feeds the GraphQL tree with Cockpit Headless CMS collections and singletons data. Actually, it supports querying raw texts (and any trivial field types), Markdown, images, galleries, assets, sets, repeaters, layout(-grid)s (currently only without nested images/assets), objects, linked collections and internationalization.",
+  "version": "1.1.2",
+  "description": "This is a Gatsby version 2.x.x source plugin that feeds the GraphQL tree with Cockpit Headless CMS collections and singletons data. Actually, it supports querying raw texts (and any trivial field types), Markdown, Wysiwyg, images, galleries, assets, sets, repeaters, layout(-grid)s (currently only without nested images/assets), objects, linked collections and internationalization.",
   "main": "gatsby-node.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -46,7 +46,8 @@
     "react-styling": "^1.6.4",
     "sanitize-html": "^1.20.0",
     "slugify": "^1.3.4",
-    "string-hash": "^1.1.3"
+    "string-hash": "^1.1.3",
+    "node-html-parser": "1.1.16"
   },
   "devDependencies": {
     "husky": "^1.3.1",

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 This is a Gatsby version 2.\*.\* source plugin that feeds the GraphQL tree with Cockpit Headless CMS collections and singletons data.
 
-Actually, it supports querying raw texts (and any trivial field types), Markdown, images, galleries, assets, sets, repeaters, layout(-grid)s (currently only without nested images/assets), objects, linked collections and internationalization.
+Actually, it supports querying raw texts (and any trivial field types), Markdown, Wysiwyg, images, galleries, assets, sets, repeaters, layout(-grid)s (currently only without nested images/assets), objects, linked collections and internationalization.
 
 ## Installation
 
@@ -246,6 +246,10 @@ Markdown fields nested within a collection or singleton will get a custom Markdo
 Notes:
 
 1. You can access the raw Markdown with this attribute.
+
+#### Wysiwygs
+
+Wysiwyg fields (or `What you see is what you get`) works the same way as Markdown fields, but instead of accessing an HTML equivalent through the `value → childMarkdownRemark → html` attribute, it's accessible straight through the `value` attribute.
 
 #### Sets
 

--- a/src/CollectionItemNodeFactory.js
+++ b/src/CollectionItemNodeFactory.js
@@ -17,13 +17,22 @@ const {
 })
 
 module.exports = class CollectionItemNodeFactory {
-  constructor(createNode, collectionName, images, assets, markdowns, layouts) {
+  constructor(
+    createNode,
+    collectionName,
+    images,
+    assets,
+    markdowns,
+    layouts,
+    baseUrl
+  ) {
     this.createNode = createNode
     this.collectionName = collectionName
     this.images = images
     this.assets = assets
     this.markdowns = markdowns
     this.layouts = layouts
+    this.baseUrl = baseUrl
 
     this.objectNodeFactory = new ObjectNodeFactory(createNode)
   }
@@ -41,7 +50,7 @@ module.exports = class CollectionItemNodeFactory {
         this.collectionName,
         node.lang === 'any' ? node.cockpitId : `${node.cockpitId}_${node.lang}`
       )
-      linkImageFieldsToImageNodes(node, this.images)
+      linkImageFieldsToImageNodes(node, this.images, this.baseUrl)
       linkAssetFieldsToAssetNodes(node, this.assets)
       linkMarkdownFieldsToMarkdownNodes(node, this.markdowns)
       linkLayoutFieldsToLayoutNodes(node, this.layouts)

--- a/src/SingletonItemNodeFactory.js
+++ b/src/SingletonItemNodeFactory.js
@@ -17,13 +17,22 @@ const {
 })
 
 module.exports = class SingletonItemNodeFactory {
-  constructor(createNode, singletonName, images, assets, markdowns, layouts) {
+  constructor(
+    createNode,
+    singletonName,
+    images,
+    assets,
+    markdowns,
+    layouts,
+    baseUrl
+  ) {
     this.createNode = createNode
     this.singletonName = singletonName
     this.images = images
     this.assets = assets
     this.markdowns = markdowns
     this.layouts = layouts
+    this.baseUrl = baseUrl
 
     this.objectNodeFactory = new ObjectNodeFactory(createNode)
   }
@@ -34,7 +43,7 @@ module.exports = class SingletonItemNodeFactory {
         this.singletonName,
         node.lang === 'any' ? node.cockpitId : `${node.cockpitId}_${node.lang}`
       )
-      linkImageFieldsToImageNodes(node, this.images)
+      linkImageFieldsToImageNodes(node, this.images, this.baseUrl)
       linkAssetFieldsToAssetNodes(node, this.assets)
       linkMarkdownFieldsToMarkdownNodes(node, this.markdowns)
       linkLayoutFieldsToLayoutNodes(node, this.layouts)


### PR DESCRIPTION
Hey there! 

I added a recognition of Image tags in the wysiwyg value. So when an cockpit asset is used the image url gets replaced by the fetched one. External images stay untouched. 

👋 